### PR TITLE
Hex argb

### DIFF
--- a/pywal/util.py
+++ b/pywal/util.py
@@ -55,6 +55,11 @@ class Color:
         return int(self.alpha_num) / 100
 
     @property
+    def alpha_hex(self):
+        """Export the alpha value as a hexdecimal number in [00, FF]."""
+        return "%02X" % (int(int(self.alpha_num) * 255 / 100))
+
+    @property
     def decimal(self):
         """Export color in decimal."""
         return "%s%s" % ("#", int(self.hex_color[1:], 16))

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -39,6 +39,12 @@ class Color:
                                       self.alpha_dec)
 
     @property
+    def hex_argb(self):
+        """Convert an alpha hex color to argb hex."""
+        return "#%02X%s" % (int(int(self.alpha_num) * 255 / 100),
+                            self.hex_color[1:])
+
+    @property
     def alpha(self):
         """Add URxvt alpha value to color."""
         return "[%s]%s" % (self.alpha_num, self.hex_color)


### PR DESCRIPTION
pull request [#578](https://github.com/dylanaraps/pywal/pull/578) @chrishoage still have not tested but correct me if i'm wrong, hex_argb does as it says and prepends the alpha value to the rgb hex values, alpha_hex on the contrary appends the alpha value in hex to the rgb hex values right?