### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -689,6 +689,9 @@ Note to self: Don't flag releases before coffee.
 
 
 [Unreleased]: https://github.com/dylanaraps/pywal/compare/3.1.0...HEAD
+[3.3.0]: https://github.com/dylanaraps/pywal/compare/3.2.1...3.3.0
+[3.2.1]: https://github.com/dylanaraps/pywal/compare/3.2.0...3.2.1
+[3.2.0]: https://github.com/dylanaraps/pywal/compare/3.1.0...3.2.0
 [3.1.0]: https://github.com/dylanaraps/pywal/compare/3.0.1...3.1.0
 [3.0.1]: https://github.com/dylanaraps/pywal/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/dylanaraps/pywal/compare/2.1.0...3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added KDE `plasma` support, wallpaper setting and template colors-nqq.css.
 - Added decimal output support, `decimal`, `decimal_strip` for templates.
 - Fixed template export, replace "." with "_".
-- Added `hsetroot` support to set wallpaper.
+- Added `hsetroot` support to set wallpaper AGAIN.
 - Added `xwallpaper` support to set wallpaper.
 - Fixed `xrdb` reload, wait until reloading is finished.
 - Added red green and blue properties to color class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed `rofi` template for rofi >v1.7.0
 - Fixed wallpaper path on microsoft windows.
 - Added `themer` template colors-themer.js.
-- Added KDE `plasma` wallpaper support.
+- Fixed gruvbox colorscheme.
+- Added KDE `plasma` support, wallpaper setting and template colors-nqq.css.
 - Added decimal output support, `decimal`, `decimal_strip` for templates.
 - Fixed template export, replace "." with "_".
 - Added `hsetroot` support to set wallpaper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.4.0] - 2022-07-?
 
+## [3.2.1] - 2018-10-24
+
+- Improved light colors (brighter colors)
+- Fixed `urxvt` background
+
 ## [3.2.0] - 2018-10-23
 
 - Simplified `colorz` backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added KDE `plasma` support, wallpaper setting and template colors-nqq.css.
 - Added decimal output support, `decimal`, `decimal_strip` for templates.
 - Fixed template export, replace "." with "_".
-- Added `hsetroot` support to set wallpaper AGAIN.
+- Fixed `hsetroot` support to set wallpaper, was duplicated.
 - Added `xwallpaper` support to set wallpaper.
 - Fixed `xrdb` reload, wait until reloading is finished.
 - Added red green and blue properties to color class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.4.0] - 2022-07-?
 
+## [3.2.0] - 2018-10-23
+
+- Simplified `colorz` backend
+- Fixed `-c` now exits
+- broken theme file removed `colorschemes/dark/dkeg-conv.sh.json`
+- wal shows usage when no args are passed.
+- Added `--preview flag` for current color palette.
+- Added `kitty` support (reload and template).
+- Fixed quiet mode with cached schemes.
+- Fixed reloading by pid.
+- Fixed Alpha setting.
+- Added support for awesomewm to set wallpaper `set_desktop_wallpaper(desktop, img)`.
+- Fixed reload `get_pid(name)` function.
+- Added hash name for cache filename.
+- Increased background contrast (darken set to 0.80, was 0.75)
+- Fixed `putty` template.
+
 ## [3.1.0] - 2018-06-21
 
 - Added `--saturate` to change color saturation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.4.0] - 2022-10-?
 
+- Fixed template exporting issue, rewriting may be necessary for a proper fix.
+- Added new properties red_dec, green_dec and blue_dec.
+- Added new properties red_hex, green_hex and blue_hex.
+- Added new property for templates `rgbspace`.
+- Added `leftwm` support template colors-leftwm-theme.ron.
 - Added support for gnome dark wallpapers.
 - Fixed crash when '~/.cache/wal' is empty.
 - Fixed `xmonad` support template Colors.hs added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.4.0] - 2022-07-?
 
+## [3.3.0] - 2018-10-24
+
+- Fixed `urxvt` borders not respecting background opacity
+- Added ENVAR PYWAL_CACHE_DIR to change cache dir.
+- Added `colors.hs` template for xmonad.
+- Added `colors-wal-dmenu.h` template for dmenu.
+- Added rgba support, funciton `rgba()`.
+- Fixed `rofi` templates.
+- Removed `oomox` support, use `wpgtk` instead.
+- Added `colors-speedcrunch.json` template.
+- Added `colors-waybar.css` template.
+- Added `--vte` to fix artifacts on vte terminals.
+- Fixed template `templates/colors-vivid.yml`.
+
 ## [3.2.1] - 2018-10-24
 
 - Improved light colors (brighter colors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,53 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.4.0] - 2022-07-?
+## [3.4.0] - 2022-10-?
+
+- Added support for gnome dark wallpapers.
+- Fixed crash when '~/.cache/wal' is empty.
+- Fixed `xmonad` support template Colors.hs added.
+- Added support for ARGB hex strings, `hexargb` and `alpha_hex`
+- Fixed color setting on OpenBSD.
+- Fixed `kitty` reloading.
+- Added `alacritty` templates colors--alacritty.yml and colors--nodim-alacritty.yml.
+- Added `--cols16` flag to generate 16 color schemes.
+- Added `fast_colorthief` backend.
+- Fixed `rofi` template for rofi >v1.7.0
+- Fixed wallpaper path on microsoft windows.
+- Added `themer` template colors-themer.js.
+- Added KDE `plasma` wallpaper support.
+- Added decimal output support, `decimal`, `decimal_strip` for templates.
+- Fixed template export, replace "." with "_".
+- Added `hsetroot` support to set wallpaper.
+- Added `xwallpaper` support to set wallpaper.
+- Fixed `xrdb` reload, wait until reloading is finished.
+- Added red green and blue properties to color class.
+- Fixed template exporting issue.
+- Added `tilix` template colors-tilix.json.
+- Added support `st` on sequences.py
+- Added ability to modify colors using `lighten`, `darken` and `saturate` in templates.
+- Added indicator to last used theme on `--theme` flag (only for provided themes).
+- Fixed eror if theme has never been set.
+- Added `stylus` template colors.styl.
+- Added base16-snazzy colorscheme.
+- Fixed `pidof` in MacOS.
+- Added support `xfce` 4.12 and later.
+- Fixed `kitty` support.
+- Added `--recursive` option to search images in all subdird of the given dir.
+- Fixed template `colors.sh` wallpaper quoting.
+- Fixed `iterm2` cursor color.
+- Fixed MacOS mojave Dock Crash.
+- Added ability to load random user theme.
+- Added ability to load random theme.
+- Added ability to saving user themes.
+- Added `bspwm` color setting support.
+- Improved file size caching to avoid image name collisions.
+- Fixed skip .swp files.
+- Improved print error message when template cannot be read
+- Improved use XDG dirs.
+- Fixed error if `pidof` is not installed.
+- Fixed `awesomewm` wallpaper setting.
+- Added vscode template `colors-vscode.json`
 
 ## [3.3.0] - 2019-01-21
 
@@ -688,7 +734,8 @@ Note to self: Don't flag releases before coffee.
 
 
 
-[Unreleased]: https://github.com/dylanaraps/pywal/compare/3.1.0...HEAD
+[Unreleased]: https://github.com/eylles/pywal16/compare/3.3.0...HEAD
+[3.4.0]: https://github.com/eylles/pywal16/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/dylanaraps/pywal/compare/3.2.1...3.3.0
 [3.2.1]: https://github.com/dylanaraps/pywal/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/dylanaraps/pywal/compare/3.1.0...3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.4.0] - 2022-07-?
 
 ## [3.1.0] - 2018-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.4.0] - 2022-07-?
 
-## [3.3.0] - 2018-10-24
+## [3.3.0] - 2019-01-21
 
 - Fixed `urxvt` borders not respecting background opacity
 - Added ENVAR PYWAL_CACHE_DIR to change cache dir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added indicator to last used theme on `--theme` flag (only for provided themes).
 - Fixed eror if theme has never been set.
 - Added `stylus` template colors.styl.
+- Added `-w` flag to use last wallpaper for color generation.
 - Added base16-snazzy colorscheme.
 - Fixed `pidof` in MacOS.
 - Added support `xfce` 4.12 and later.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+## This project is a 16 colors fork of [pywal](https://github.com/dylanaraps/pywal)
 <h3 align="center"><img src="https://i.imgur.com/5WgMACe.gif" width="200px"></h3>
 <p align="center">Generate and change color-schemes on the fly.</p>
 
@@ -18,4 +19,4 @@ The goal of Pywal was to be as out of the way as possible. It doesn't modify any
 
 Terminal emulators and TTYs have their color-schemes updated in real-time with no delay. With minimal configuration this functionality can be extended to almost anything running on your system.
 
-### More: \[[Installation](https://github.com/dylanaraps/pywal/wiki/Installation)] \[[Getting Started](https://github.com/dylanaraps/pywal/wiki/Getting-Started)] \[[Customization](https://github.com/dylanaraps/pywal/wiki/Customization)] \[[Wiki](https://github.com/dylanaraps/pywal/wiki)] \[[Screenshots](https://www.reddit.com/r/unixporn/search?q=wal&restrict_sr=on&sort=relevance&t=all)]
+### More: \[[Installation](https://github.com/eylles/pywal16/wiki/Installation)] \[[Getting Started](https://github.com/eylles/pywal16/wiki/Getting-Started)] \[[Customization](https://github.com/eylles/pywal16/wiki/Customization)] \[[Wiki](https://github.com/eylles/pywal16/wiki)] \[[Screenshots](https://www.reddit.com/r/unixporn/search?q=wal&restrict_sr=on&sort=relevance&t=all)]

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 <p align="center">
 <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
-<a href="https://pypi.python.org/pypi/pywal/"><img src="https://img.shields.io/pypi/v/pywal.svg"></a>
+<a href="https://pypi.python.org/pypi/pywal16/"><img src="https://img.shields.io/pypi/v/pywal16.svg"></a>
 </p>
 
 <img src="https://i.imgur.com/HhK3LDv.jpg" alt="img" align="right" width="400px">
+
+<img src="https://i.imgur.com/yLFlPaQ.png" alt="img 16 cols" align="right" width="400px">
 
 Pywal is a tool that generates a color palette from the dominant colors in an image. It then applies the colors system-wide and on-the-fly in all of your favourite programs.  
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,8 @@
 <p align="center">Generate and change color-schemes on the fly.</p>
 
 <p align="center">
-<a href="https://travis-ci.org/dylanaraps/pywal"><img src="https://travis-ci.org/dylanaraps/pywal.svg?branch=master"></a>
 <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 <a href="https://pypi.python.org/pypi/pywal/"><img src="https://img.shields.io/pypi/v/pywal.svg"></a>
-<a href="https://www.patreon.com/dyla"><img src="https://img.shields.io/badge/donate-patreon-yellow.svg"></a>
-<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=V7QNJNKS3WYVS"><img src="https://img.shields.io/badge/donate-paypal-green.svg"></a>
 </p>
 
 <img src="https://i.imgur.com/HhK3LDv.jpg" alt="img" align="right" width="400px">

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 <a href="https://pypi.python.org/pypi/pywal16/"><img src="https://img.shields.io/pypi/v/pywal16.svg"></a>
 </p>
 
-<img src="https://i.imgur.com/HhK3LDv.jpg" alt="img" align="right" width="400px">
-
-<img src="https://i.imgur.com/yLFlPaQ.png" alt="img 16 cols" align="right" width="400px">
+<img src="https://i.imgur.com/V1FuvJP.png" alt="img" align="right" width="400px">
 
 Pywal is a tool that generates a color palette from the dominant colors in an image. It then applies the colors system-wide and on-the-fly in all of your favourite programs.  
 

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -13,7 +13,7 @@ import os
 import platform
 
 
-__version__ = "3.3.1"
+__version__ = "3.4.0"
 __cache_version__ = "1.1.0"
 
 

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -100,10 +100,7 @@ def set_desktop_wallpaper(desktop, img):
     elif "gnome" in desktop or "unity" in desktop:
         util.disown(["gsettings", "set",
                      "org.gnome.desktop.background",
-                     "picture-uri-dark", "file://" + urllib.parse.quote(img)])
-        util.disown(["gsettings", "set",
-                      "org.gnome.desktop.background",
-                      "picture-uri", "file://" + urllib.parse.quote(img)])
+                     "picture-uri", "file://" + urllib.parse.quote(img)])
 
     elif "mate" in desktop:
         util.disown(["gsettings", "set", "org.mate.background",

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -65,9 +65,6 @@ def set_wm_wallpaper(img):
     elif shutil.which("xwallpaper"):
         util.disown(["xwallpaper", "--zoom", img])
 
-    elif shutil.which("hsetroot"):
-        util.disown(["hsetroot", "-fill", img])
-
     elif shutil.which("nitrogen"):
         util.disown(["nitrogen", "--set-zoom-fill", img])
 

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -100,7 +100,10 @@ def set_desktop_wallpaper(desktop, img):
     elif "gnome" in desktop or "unity" in desktop:
         util.disown(["gsettings", "set",
                      "org.gnome.desktop.background",
-                     "picture-uri", "file://" + urllib.parse.quote(img)])
+                     "picture-uri-dark", "file://" + urllib.parse.quote(img)])
+        util.disown(["gsettings", "set",
+                      "org.gnome.desktop.background",
+                      "picture-uri", "file://" + urllib.parse.quote(img)])
 
     elif "mate" in desktop:
         util.disown(["gsettings", "set", "org.mate.background",


### PR DESCRIPTION
preparing for release 3.4.0

- [x] change old links form readme
- [x] update readme (add screenshots of the 16 color generation)
- [x] properly document past changelog (dylan stopped at release 3.1.0):
    - [x] release 3.2.0 changelog
    - [x] release 3.2.1 changelog
    - [x] release 3.3.0 changelog
- [x] copy pywal's wiki
- [x] merge support for gnome dark mode wallpapers
~~update the wiki~~ this can be done AFTER releasing 
- [x] release 3.4.0 changelog

maybe i should put the CI in github itself, then upload to pypi