### PR TITLE
Add template for leftwm `theme.ron`

### DIFF
--- a/pywal/templates/colors-leftwm-theme.ron
+++ b/pywal/templates/colors-leftwm-theme.ron
@@ -1,0 +1,9 @@
+#![enable(implicit_some)]
+(
+    border_width: 2,
+    margin: [4, 4],
+    default_border_color: "{background}",
+    floating_border_color: "{color6}",
+    focused_border_color: "{foreground}",
+    background_color: "{background}",
+)


### PR DESCRIPTION
As suggested in [PyWal #688](https://github.com/dylanaraps/pywal/issues/688) here is a template for creating a `theme.ron`.
It was tested a couple of weeks ago with original `pywal`, except the `background_color` which is [a new feature](https://github.com/leftwm/leftwm/pull/922) that is expected to become merged by the end of the week.
@arcolinux could you give this another test spin?

Edit: also worth noting, the `background_color` will go unseen in almost any use cases, but I thought it might make sense to style all available color fields.