### PR TITLE
Revert "Adding support for gnome dark mode wallpapers"

### DIFF
--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -100,10 +100,7 @@ def set_desktop_wallpaper(desktop, img):
     elif "gnome" in desktop or "unity" in desktop:
         util.disown(["gsettings", "set",
                      "org.gnome.desktop.background",
-                     "picture-uri-dark", "file://" + urllib.parse.quote(img)])
-        util.disown(["gsettings", "set",
-                      "org.gnome.desktop.background",
-                      "picture-uri", "file://" + urllib.parse.quote(img)])
+                     "picture-uri", "file://" + urllib.parse.quote(img)])
 
     elif "mate" in desktop:
         util.disown(["gsettings", "set", "org.mate.background",


### PR DESCRIPTION
Reverts eylles/pywal16#10

merging that to the release tag branch was the wrong decision, it should be merged to master.