### PR TITLE
Change alacritty template to match v0.11.0+ config

### DIFF
--- a/pywal/templates/colors--nodim-alacritty.yml
+++ b/pywal/templates/colors--nodim-alacritty.yml
@@ -20,13 +20,13 @@ colors:
       foreground: CellBackground
       background: CellForeground
 
-    bar:
-      foreground: '{color8}'
-      background: '{color7}'
-
   line_indicator:
     foreground: None
     background: None
+
+  footer_bar:
+    foreground: '{color8}'
+    background: '{color7}'
 
   selection:
     text: CellBackground

--- a/pywal/templates/colors-alacritty.yml
+++ b/pywal/templates/colors-alacritty.yml
@@ -20,13 +20,13 @@ colors:
       foreground: CellBackground
       background: CellForeground
 
-    bar:
-      foreground: '{color8}'
-      background: '{color7}'
-
   line_indicator:
     foreground: None
     background: None
+
+  footer_bar:
+    foreground: '{color8}'
+    background: '{color7}'
 
   selection:
     text: CellBackground


### PR DESCRIPTION
As of Alacritty release 0.11.0, the syntax for setting the color of the bar changed from being nested under search to being it's own item "footer_bar". This fix matches the current Alacritty syntax and should remove the warning popup from Alacritty when loading the old style config.

Reference:
- [old config](https://github.com/alacritty/alacritty/blob/v0.10.1/alacritty.yml)
- [new config](https://github.com/alacritty/alacritty/blob/v0.11.0/alacritty.yml)