### PR TITLE
Added swaybg support

### DIFF
--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -62,6 +62,10 @@ def set_wm_wallpaper(img):
     if shutil.which("swww"):
         util.disown(["swww", "img", img])
 
+    elif shutil.which("swayb"):
+        subprocess.call(["killall", "swaybg"])
+        util.disown(["swaybg", "-m", "fill", "-i", img])
+
     elif shutil.which("feh"):
         util.disown(["feh", "--bg-fill", img])
 


### PR DESCRIPTION
pull request [#711](https://github.com/dylanaraps/pywal/pull/711)

@madstone0-0 just an interesting pattern i noticed both swaybg and swww take precedence before feh, my first thought is that is because a wayland environment could expect to find feh as part of xwayland and try to set the wallpaper there instead of where it should be setting it, no need to answer was just something i thought.