### PR TITLE
fix empty message on plasma

### DIFF
--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -89,6 +89,9 @@ def send(colors, cache_dir=CACHE_DIR, to_send=True, vte_fix=False):
     # Send data to open terminal devices.
     if to_send:
         for dev in devices:
+            if dev == "/dev/pts/0":
+                if os.environ["DESKTOP_SESSION"] == "plasma":
+                    continue
             util.save_file(sequences, dev)
 
     util.save_file(sequences, os.path.join(cache_dir, "sequences"))


### PR DESCRIPTION
sending to /dev/pts/0 leads to a erronious notification on KDE plasma. not breaking, but annoying.

adds a check to not do that when the DE is "plasma", addition of other DEs with the problem welcome