### PR TITLE
No fcntl on unsupported platform

### DIFF
--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -86,6 +86,9 @@ def send(colors, cache_dir=CACHE_DIR, to_send=True, vte_fix=False):
 
     sequences = create_sequences(colors, vte_fix)
 
+    if not util.has_fcntl:
+        logging.warning(util.fcntl_warning)
+
     # Send data to open terminal devices.
     if to_send:
         for dev in devices:


### PR DESCRIPTION
could not find a way to do non blocking io checks with portalocker the way it can be done with fcntl, this should address #49 