### PR TITLE
add cols16 method when generating 16 cols

### DIFF
--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -146,16 +146,29 @@ def cache_fname(img, backend, cols16, light, cache_dir, sat=""):
     file_name = re.sub("[/|\\|.]", "_", img)
     file_size = os.path.getsize(img)
 
-    file_parts = [
-        file_name,
-        color_num,
-        color_type,
-        backend,
-        sat,
-        file_size,
-        __cache_version__,
-    ]
-    return [cache_dir, "schemes", "%s_%s_%s_%s_%s_%s_%s.json" % (*file_parts,)]
+    if cols16:
+        file_parts = [
+            file_name,
+            color_num,
+            cols16,
+            color_type,
+            backend,
+            sat,
+            file_size,
+            __cache_version__,
+        ]
+        return [cache_dir, "schemes", "%s_%s_%s_%s_%s_%s_%s_%s.json" % (*file_parts,)]
+    else:
+        file_parts = [
+            file_name,
+            color_num,
+            color_type,
+            backend,
+            sat,
+            file_size,
+            __cache_version__,
+        ]
+        return [cache_dir, "schemes", "%s_%s_%s_%s_%s_%s_%s.json" % (*file_parts,)]
 
 
 def get_backend(backend):


### PR DESCRIPTION
this is so that when you generate a 16 cols scheme you get `<image name>_16_lighten_...` or `<image name>_16_darken_...` and you don't have the issue of generating with one method, then generating with the other and pywal choosing the cached colorscheme made with the wrong method.