### PR TITLE
Add (optional) dependencies to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ Terminal emulators and TTYs have their color-schemes updated in real-time with n
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/pywal16.svg)](https://repology.org/project/pywal16/versions)
 
+### Developement notes
+
+#### Regular install
+
+No dependencies, MUST provided native executables:
+
+    pip install "pywal16"
+
+Install colorthief dependency automatically:
+
+    pip install "pywal16[colorthief]"
+
+Install all dependencies:
+
+    pip install "pywal16[all]"
+
+#### Developement checkout install
+
+No dependencies, MUST provided native executables:
+
+    python -m pip install -e .
+
+Install colorthief dependency automatically:
+
+    python -m pip install -e ".[colorthief]"
+
+Install all dependencies:
+
+    python -m pip install -e ".[all]"
+
+
 <p align="right">
 support me at:
 <br>

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,14 @@ setuptools.setup(
     packages=["pywal"],
     entry_points={"console_scripts": ["wal=pywal.__main__:main"]},
     python_requires=">=3.5",
+    extras_require={
+        'colorthief': ['colorthief', ],  # known to work with 0.2.1
+        'colorz': ['colorz', ],  # NOTE heavy, scipy dependency
+        'fast-colorthief': ['fast-colorthief', ],
+        'haishoku': ['haishoku', ],
+        'modern_colorthief': ['modern_colorthief', ],
+        'all': ['colorthief', 'colorz', 'fast-colorthief', 'haishoku', 'modern_colorthief'],  # convience, all of the above
+    },
     test_suite="tests",
     include_package_data=True,
     zip_safe=False)


### PR DESCRIPTION
Allow pywal16 to be used immediately after install, without manual setup and post-installation step(s).