### PR TITLE
Missing checksum in test_file.json caused pytest to fail

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -8,7 +8,7 @@ from pywal import export
 from pywal import util
 
 
-COLORS = util.read_file_json("tests/test_files/test_file.json")
+COLORS = util.read_file_json("tests/test_files/test_file3.json")
 COLORS["colors"].update(COLORS["special"])
 
 TMP_DIR = "/tmp/wal"


### PR DESCRIPTION
pytest failed in the latest 3.7.0

```
> =========================== short test summary info ============================
> FAILED tests/test_export.py::TestExportColors::test_all_templates - KeyError: 'checksum'
> FAILED tests/test_export.py::TestExportColors::test_css_template - KeyError: 'checksum'
```

Both tests in `test_export.py` use `export.every()`, and the function call chain is as followed:

https://github.com/eylles/pywal16/blob/784d0b9aaec945478342601258626372baae806b/tests/test_export.py#L41
https://github.com/eylles/pywal16/blob/784d0b9aaec945478342601258626372baae806b/pywal/export.py#L120-L122
https://github.com/eylles/pywal16/blob/784d0b9aaec945478342601258626372baae806b/pywal/export.py#L75-L85

#79 added exporting checksum in `flatten_colors()`, which requires that the imported test file must have a `checksum` field. Considering that `test_file.json` is used by other tests, perhaps the easiest way to fix it is to replace the `test_file.json` used in `test_export.py` with `test_file3.json`?

https://github.com/eylles/pywal16/blob/784d0b9aaec945478342601258626372baae806b/tests/test_export.py#L11
