### PR TITLE
Fix colorama import to restrict usage to Windows systems only

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -15,12 +15,10 @@ import os
 import shutil
 import sys
 
-try:
+if sys.platform.startswith("win"):
     import colorama
 
-    colorama.just_fix_windows_console()  # NOOP for non-Windows
-except ImportError:
-    pass
+    colorama.just_fix_windows_console()
 
 from .settings import __version__, CACHE_DIR, CONF_DIR
 from . import colors


### PR DESCRIPTION
Hello
Recently, I made a fresh installation of Linux Mint (specifically Linux Mint 21.2 Victoria) on my machine, and I installed `pywal16` using `pip3`. Everything was going fine until I tried to execute it with the `wal`  command, and I and got this error.

```
Traceback (most recent call last):
  File "/home/josh/.local/bin/wal", line 5, in <module>
    from pywal.__main__ import main
  File "/home/josh/.local/lib/python3.10/site-packages/pywal/__main__.py", line 21, in <module>
    colorama.just_fix_windows_console()  # NOOP for non-Windows
AttributeError: module 'colorama' has no attribute 'just_fix_windows_console'
```

As the error says, python couldn’t find any function related to the `colorama` library. And after doing some research, I found that #70 introduced some changes to the code for using pywal in windows terminals. I also found that for some reason the library was already installed on my system, but it didn’t include the function `just_fix_windows_console()`.  
Code line related: https://github.com/eylles/pywal16/blob/565b6566122eae0c7c765501ffdb38712514fafe/pywal/__main__.py#L18-L23

I assume the library came preinstalled with the Linux Mint installation or was included in a package I installed using the package manager (apt). In any case, the package is called `python3-colorama`, it seems to be an older version that doesn’t include the function related to the error.

So, since the code in pywal is only used for Windows terminals and can cause this error even on other Ubuntu-based distributions, I think it would be better to simply ignore the library on non-windows systems.
