### PR TITLE
Change dwm selection bg colour to match dmenu's

### DIFF
--- a/pywal/templates/colors-wal-dwm.h
+++ b/pywal/templates/colors-wal-dwm.h
@@ -3,7 +3,7 @@ static const char norm_bg[] = "{color0}";
 static const char norm_border[] = "{color8}";
 
 static const char sel_fg[] = "{color15}";
-static const char sel_bg[] = "{color2}";
+static const char sel_bg[] = "{color1}";
 static const char sel_border[] = "{color15}";
 
 static const char *colors[][3]      = {{


### PR DESCRIPTION
dwm and dmenu are very often used together and thus should share the same palette. Favouring dmenu's selection bg colour over dwm's is mostly arbitrary. I think dmenu's (color1) tends to look better, and [rofi uses it as well](https://github.com/eylles/pywal16/blob/master/pywal/templates/colors-rofi-light.rasi#L16) so there's some precedent.
What's most important is that they match.