### PR TITLE
Add templates for fuzzel, mako, tofi, and zathura

### DIFF
--- a/pywal/templates/colors-fuzzel.ini
+++ b/pywal/templates/colors-fuzzel.ini
@@ -1,0 +1,11 @@
+[colors]
+background={background.strip}ff
+prompt={foreground.strip}ff
+text={foreground.strip}ff
+placeholder={foreground.strip}ff
+input={foreground.strip}ff
+match={foreground.strip}ff
+selection={color1.strip}ff
+selection-text={background.strip}ff
+selection-match={foreground.strip}ff
+border={color1.strip}ff

--- a/pywal/templates/colors-mako
+++ b/pywal/templates/colors-mako
@@ -1,0 +1,3 @@
+background-color={background}
+text-color={foreground}
+border-color={color1}

--- a/pywal/templates/colors-tofi
+++ b/pywal/templates/colors-tofi
@@ -1,0 +1,4 @@
+background-color = {background.strip}
+border-color = {color1.strip}
+selection-color = {color1.strip}
+text-color = {foreground.strip}

--- a/pywal/templates/colors-zathura
+++ b/pywal/templates/colors-zathura
@@ -1,0 +1,34 @@
+set recolor "true"
+set recolor-keephue "true"
+
+set completion-bg "{background}"
+set completion-fg "{foreground}"
+set completion-group-bg "{background}"
+set completion-group-fg "{color2}"
+set completion-highlight-bg "{foreground}"
+set completion-highlight-fg "{background}"
+
+set recolor-lightcolor "{background}"
+set recolor-darkcolor "{foreground}"
+set default-bg "{background}"
+
+set inputbar-bg "{background}"
+set inputbar-fg "{foreground}"
+set notification-bg "{background}"
+set notification-fg "{foreground}"
+set notification-error-bg "{color1}"
+set notification-error-fg "{foreground}"
+set notification-warning-bg "{color1}"
+set notification-warning-fg "{foreground}"
+set statusbar-bg "{background}"
+set statusbar-fg "{foreground}"
+set index-bg "{background}"
+set index-fg "{foreground}"
+set index-active-bg "{foreground}"
+set index-active-fg "{background}"
+set render-loading-bg "{background}"
+set render-loading-fg "{foreground}"
+
+set window-title-home-tilde true
+set statusbar-basename true
+set selection-clipboard clipboard


### PR DESCRIPTION
This commit adds templates for the following programs: [fuzzel](https://codeberg.org/dnkl/fuzzel), [mako](https://github.com/emersion/mako), [tofi](https://github.com/philj56/tofi) and [zathura](https://github.com/pwmt/zathura). All of these can be imported/included to your already existing configurations.

## Gallery
### Mako
![image](https://github.com/user-attachments/assets/cb311745-4a04-4e8b-a6d9-968f6ddf49df)

Add `include=/home/amolinae/.cache/wal/colors-mako` to your mako configuration.

**NOTE:** requires [this commit](https://github.com/emersion/mako/commit/4d48aca5f3c92d9c01282cd40b8d3b2c959bdac6) for it to work.

### Zathura
![image](https://github.com/user-attachments/assets/6b35221a-eb94-4128-b381-a67ddbcad318)

Add `include /home/youruser/.cache/wal/colors-zathura` to your zathurarc.

**NOTE:** This template changes the page color to match with your colorscheme.

### Fuzzel
![image](https://github.com/user-attachments/assets/44347109-2c16-415e-8c4f-8a1b9ff7731a)

 Add `include = include = ~/.cache/wal/colors-fuzzel.ini` to your fuzzel configuration.

### Tofi
![image](https://github.com/user-attachments/assets/dc8cbd4c-5a6c-4e2d-bda7-b39bcec75a6a)
 
 Add `include = /home/youruser/.cache/wal/colors-tofi` to your configuration.

