### PR TITLE
retroarch rgui template

### DIFF
--- a/pywal/templates/colors-retroarch.cfg
+++ b/pywal/templates/colors-retroarch.cfg
@@ -1,0 +1,8 @@
+rgui_entry_normal_color = "0xFF{color9.strip}"
+rgui_entry_hover_color = "0xFF{color14.strip}"
+rgui_title_color = "0xFF{color15.strip}"
+rgui_bg_dark_color = "0xFF{background.strip}"
+rgui_bg_light_color = "0xFF{background.strip}"
+rgui_border_dark_color = "0xFF{color8.strip}"
+rgui_border_light_color = "0xFF{color8.strip}"
+rgui_particle_color = "0xFF{color4.strip}"


### PR DESCRIPTION
you will need to set ```menu_driver = "rgui"```, ```rgui_menu_color_theme = "0"``` and ```rgui_menu_theme_preset = "~/.cache/wal/colors-retroarch.cfg"``` in your retroarch config

![Screenshot_2025-03-04-17-31-02_29658](https://github.com/user-attachments/assets/713311d5-4948-4469-852a-7304ad421e98)
