### PR TITLE
Set alpha_num even when user specifies theme file

### DIFF
--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -107,6 +107,8 @@ def parse(theme_file):
 
     if "alpha" not in data:
         data["alpha"] = util.Color.alpha_num
+    else:
+        util.Color.alpha_num = data["alpha"]
 
     # Terminal.sexy format.
     if "color" in data:


### PR DESCRIPTION
Previously util.Color's class variable alpha_num was set only when the user supplied an alpha value on the command line. This meant that functions using it (namely alpha_hex and alpha_dec) used the default alpha_num value of 100 any time the user specified a JSON/YAML theme file (as opposed to manually specifying an alpha value with command-line flag -a).