### PR TITLE
Warn when colorama is not present on windows

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -24,7 +24,6 @@ if sys.platform.startswith("win"):
         if (winterm != "wezterm") and \
            (winterm != "alacritty") and \
            (winterm != "hyper") and \
-           (winterm != "kitty") and \
            (winterm != "putty") and \
            (winterm != "ghostty") and \
            (winterm != "mintty"):

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -28,8 +28,8 @@ if sys.platform.startswith("win"):
                 "ghostty",
                 "mintty",
                 ]
-        winterm = os.environ.get("TERMINAL")
-        if winterm not in no_colorama_terms:
+        if os.environ.get("TERMINAL") not in no_colorama_terms and \
+           os.environ.get("TERM_PROGRAM") not in no_colorama_terms:
             show_colorama_warning = True
 
 from .settings import __version__, CACHE_DIR, CONF_DIR

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -15,6 +15,19 @@ import os
 import shutil
 import sys
 
+from .settings import __version__, CACHE_DIR, CONF_DIR
+from . import colors
+from . import export
+from . import image
+from . import reload
+from . import sequences
+from . import theme
+from . import util
+from . import wallpaper
+from . import donation
+from . import eastereggs
+
+
 show_colorama_warning = False
 if sys.platform.startswith("win"):
     try:
@@ -32,18 +45,6 @@ if sys.platform.startswith("win"):
         if os.environ.get("TERMINAL") not in no_colorama_terms and \
            os.environ.get("TERM_PROGRAM") not in no_colorama_terms:
             show_colorama_warning = True
-
-from .settings import __version__, CACHE_DIR, CONF_DIR
-from . import colors
-from . import export
-from . import image
-from . import reload
-from . import sequences
-from . import theme
-from . import util
-from . import wallpaper
-from . import donation
-from . import eastereggs
 
 
 def get_args():

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import sys
 
+show_colorama_warning = False
 if sys.platform.startswith("win"):
     try:
         import colorama

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -20,13 +20,16 @@ if sys.platform.startswith("win"):
         import colorama
         colorama.just_fix_windows_console()
     except ImportError:
+        no_colorama_terms = [
+                "wezterm",
+                "alacritty",
+                "hyper",
+                "putty",
+                "ghostty",
+                "mintty",
+                ]
         winterm = os.environ.get("TERMINAL")
-        if (winterm != "wezterm") and \
-           (winterm != "alacritty") and \
-           (winterm != "hyper") and \
-           (winterm != "putty") and \
-           (winterm != "ghostty") and \
-           (winterm != "mintty"):
+        if winterm not in no_colorama_terms:
             show_colorama_warning = True
 
 from .settings import __version__, CACHE_DIR, CONF_DIR

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -15,11 +15,20 @@ import os
 import shutil
 import sys
 
-try:
-    import colorama
-    colorama.just_fix_windows_console()
-except ImportError:
-    colorama = None
+if sys.platform.startswith("win"):
+    try:
+        import colorama
+        colorama.just_fix_windows_console()
+    except ImportError:
+        winterm = os.environ.get("TERMINAL")
+        if (winterm != "wezterm") and \
+           (winterm != "alacritty") and \
+           (winterm != "hyper") and \
+           (winterm != "kitty") and \
+           (winterm != "putty") and \
+           (winterm != "ghostty") and \
+           (winterm != "mintty"):
+            show_colorama_warning = True
 
 from .settings import __version__, CACHE_DIR, CONF_DIR
 from . import colors
@@ -332,6 +341,10 @@ def main():
     util.create_dir(os.path.join(CONF_DIR, "colorschemes/dark/"))
 
     util.setup_logging()
+
+    if show_colorama_warning:
+        logging.warning("colorama is not present")
+
     parser = get_args()
 
     parse_args_exit(parser)


### PR DESCRIPTION
The warning is issued on windows when the current TERMINAL is not one of the terminal emulators that do not require the just_fix_windows_console function.

this should fix #150 without affecting other platforms like linux, mac or bsd.