### PR TITLE
Prefer passed alpha over theme alpha

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -273,7 +273,8 @@ def parse_args(parser):
         sys.stdout = sys.stderr = open(os.devnull, "w")
 
     if args.a:
-        util.Color.alpha_num = args.a
+        util.Color.passed_alpha_num = args.a
+        util.Color.alpha_num = args.a or util.Color.alpha_num
 
     if args.i and not args.theme:
         image_file = image.get(

--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -460,7 +460,6 @@ def get(
         "checksum"
     ] == util.get_img_checksum(img):
         colors = theme.file(cache_file)
-        colors["alpha"] = util.Color.alpha_num
         logging.info("Found cached colorscheme.")
 
     else:

--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -105,7 +105,7 @@ def parse(theme_file):
     if "wallpaper" not in data:
         data["wallpaper"] = "None"
 
-    if "alpha" not in data:
+    if util.Color.passed_alpha_num or "alpha" not in data:
         data["alpha"] = util.Color.alpha_num
     else:
         util.Color.alpha_num = data["alpha"]

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -32,6 +32,7 @@ class Color:
     """Color formats."""
 
     alpha_num = "100"
+    passed_alpha_num = None
 
     def __init__(self, hex_color):
         self.hex_color = hex_color


### PR DESCRIPTION
Since 2122595ae32f649120133263b8316ee1a744847b the alpha being passed with `-a` was no longer respected. I have tested manually somewhat and the pytests passed, but might be worth a look over.