### PR TITLE
foxify colors

### DIFF
--- a/pywal/util.py
+++ b/pywal/util.py
@@ -183,6 +183,10 @@ class Color:
         percent = float(re.sub(r"[\D\.]", "", str(percent)))
         return Color(darken_color(self.hex_color, percent / 100))
 
+    def foxify(self, amount):
+        """Foxify color by amount."""
+        return Color(foxify_color(self.hex_color, amount))
+
     def saturate(self, percent):
         """Saturate a color."""
         percent = float(re.sub(r"[\D\.]", "", str(percent)))
@@ -304,6 +308,17 @@ def lighten_color(color, amount):
     """Lighten a hex color."""
     color = [int(col + (255 - col) * amount) for col in hex_to_rgb(color)]
     return rgb_to_hex(color)
+
+
+def foxify_color(color, f):
+    """pywalfox algorithm to lighten colors"""
+    pwf = float(f)
+    c = hex_to_rgb(color)
+    b = []
+    b.append(min((max(0, int(c[0] + (c[0] * pwf)))), 255))
+    b.append(min((max(0, int(c[1] + (c[1] * pwf)))), 255))
+    b.append(min((max(0, int(c[2] + (c[2] * pwf)))), 255))
+    return rgb_to_hex(b)
 
 
 def blend_color(color, color2):


### PR DESCRIPTION
This adds the ability to change colors with the pywalfox algorithm.

blocking:
- [ ] #13 


unfortunately this is a time when once again i'm hitting face first into the wall that is #13 

which means that it would only be possible to add colors modified like this as part of the special colors in the main color dict, not allow users to call the foxify property from a template as the way template export function is defined at:
https://github.com/eylles/pywal16/blob/ec2ad5a02bd98ca9dcba0230b92075840cbd80c4/pywal/export.py#L24-L83

as a finditer and such careless reggular expression usage should have never been part of the function... but we are already past beyond that point...

anyway will have to leave this open until that problem is eventually fixed.