### PR TITLE
Change behaviour of --saturate flag

### DIFF
--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -186,7 +186,7 @@ def saturate_colors(colors, amount):
     if amount and (float(amount) <= 1.0 and float(amount) >= -1.0):
         for i, _ in enumerate(colors):
             if i not in [7, 15]:
-                colors[i] = util.saturate_color(colors[i], float(amount))
+                colors[i] = util.add_saturation(colors[i], float(amount))
 
     return colors
 

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -342,11 +342,27 @@ def blend_color(color, color2):
 
 
 def saturate_color(color, amount):
-    """Saturate a hex color."""
+    """Change saturation of a hex color to passed value."""
     r, g, b = hex_to_rgb(color)
     r, g, b = [x / 255.0 for x in (r, g, b)]
     h, l, s = colorsys.rgb_to_hls(r, g, b)
     s = amount
+    r, g, b = colorsys.hls_to_rgb(h, l, s)
+    r, g, b = [x * 255.0 for x in (r, g, b)]
+
+    return rgb_to_hex((int(r), int(g), int(b)))
+
+
+def add_saturation(color, amount):
+    """Add saturation to a hex color."""
+    r, g, b = hex_to_rgb(color)
+    r, g, b = [x / 255.0 for x in (r, g, b)]
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    s = s + amount
+    if s > 1.0:
+        s = 1
+    if s < -1.0:
+        s = -1
     r, g, b = colorsys.hls_to_rgb(h, l, s)
     r, g, b = [x * 255.0 for x in (r, g, b)]
 

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -342,7 +342,9 @@ def blend_color(color, color2):
 
 
 def saturate_color(color, amount):
-    """Change saturation of a hex color to passed value."""
+    """Change saturation of a hex color to passed value.
+
+    new_saturation = amount"""
     r, g, b = hex_to_rgb(color)
     r, g, b = [x / 255.0 for x in (r, g, b)]
     h, l, s = colorsys.rgb_to_hls(r, g, b)
@@ -354,7 +356,9 @@ def saturate_color(color, amount):
 
 
 def add_saturation(color, amount):
-    """Add saturation to a hex color."""
+    """Add saturation to a hex color.
+
+    new_saturation = color_saturation + amount"""
     r, g, b = hex_to_rgb(color)
     r, g, b = [x / 255.0 for x in (r, g, b)]
     h, l, s = colorsys.rgb_to_hls(r, g, b)


### PR DESCRIPTION
this should modify the internal behaviour of the saturation flag so that it is more intuitive as it now adds the passed value onto the color's saturation instead of replacing it.