### PR TITLE
change to exact name pkill command for waybar and polybar

### DIFF
--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -72,7 +72,7 @@ def kitty():
 def polybar():
     """Reload polybar colors."""
     if shutil.which("polybar") and util.get_pid("polybar"):
-        util.disown(["pkill", "-USR1", "polybar"])
+        util.disown(["pkill", "-x", "-USR1", "polybar"])
 
 
 def sway():
@@ -90,7 +90,7 @@ def firefox():
 def waybar():
     """Reload waybar colors."""
     if shutil.which("waybar") and util.get_pid("waybar"):
-        util.disown(["pkill", "-USR2", "waybar"])
+        util.disown(["pkill", "-x", "-USR2", "waybar"])
 
 
 def colors(cache_dir=CACHE_DIR):


### PR DESCRIPTION
Added `"-x",` to the pkill commands for both Waybar and Polybar, as it was the reload was killing helper scripts that have "waybar" or "polybar" in the name. This makes it safer for systems that are not yet using `"reload_style_on_change": true` in their waybar config.
