### PR TITLE
Utilise alpha parameter in foot's templata file

### DIFF
--- a/pywal/templates/colors-foot.ini
+++ b/pywal/templates/colors-foot.ini
@@ -17,3 +17,4 @@ bright4={color12.strip}
 bright5={color13.strip}
 bright6={color14.strip}
 bright7={color15.strip}
+alpha={alpha.alpha_dec}


### PR DESCRIPTION
Foot has a configuration parameter which allows to specify an alpha value. This commit simply adds use of it to the default template file. I've tested things on my system and work fine (so far!).

References:
* [foot.ini(5)](https://man.archlinux.org/man/foot.ini.5.en)
* `alpha_dec` is defined on line 82 of \`util.py'