### PR TITLE
Use a more recent python version for the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: "3.9"
+                  python-version: "3.11"
             - name: Install dependencies
               run: |
                   sudo apt-get update && \


### PR DESCRIPTION
hopefully some version shipped by a supported version of debian ought to work, as using python 3.8 may have been too old a version...