### PR TITLE
Add more explicit session type warning

### DIFF
--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -118,7 +118,17 @@ def set_wm_wallpaper(img):
             return
 
     else:
-        logging.error("Cannot set wallpaper for this session.")
+        if session_type:
+            logging.error(
+                    "Wallpaper setting not supported for"
+                    f" '{session_type}' session type."
+                    )
+        else:
+            logging.error("Cannot set wallpaper for this session.")
+        logging.error(
+                "Check XDG_SESSION_TYPE is set correctly"
+                " only x11 and wayland session types are supported."
+                )
         return
 
 


### PR DESCRIPTION
For unix-like environments pywal tries to find a desktop environment, if no known desktop environment is found then pywal will fallback to an x11 or wayland wallpaper setter, for that to work we need a correctly set XDG_SESSION_TYPE, this warning adds explicitness about this necessity.