### PR TITLE
Use standardized env variable for the empty message fix

### DIFF
--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -100,7 +100,7 @@ def send(colors, cache_dir=CACHE_DIR, to_send=True, vte_fix=False):
     if to_send:
         for dev in devices:
             if dev == "/dev/pts/0":
-                if os.environ.get("DESKTOP_SESSION") == "plasma":
+                if os.environ.get("XDG_CURRENT_DESKTOP") == "KDE" or os.environ.get("DESKTOP_SESSION") == "plasma":
                     continue
             util.save_file(sequences, dev)
 


### PR DESCRIPTION
The current env variable `DESKTOP_SESSION` is considered legacy and it wasn't even set to the value `plasma` on my system, so using the standardized `XDG_CURRENT_DESKTOP` env variable seems to be a better option. Both are checked with this change btw