### PR TITLE
Add a template for Lua (used by Hyprland since 0.55)

### DIFF
--- a/pywal/templates/colors.lua
+++ b/pywal/templates/colors.lua
@@ -1,0 +1,25 @@
+return {
+    -- Special
+    wallpaper  = "{wallpaper}",
+    background = "{background}",
+    foreground = "{foreground}",
+    cursor     = "{cursor}",
+
+    -- Colors
+    color0     = "{color0}",
+    color1     = "{color1}",
+    color2     = "{color2}",
+    color3     = "{color3}",
+    color4     = "{color4}",
+    color5     = "{color5}",
+    color6     = "{color6}",
+    color7     = "{color7}",
+    color8     = "{color8}",
+    color9     = "{color9}",
+    color10    = "{color10}",
+    color11    = "{color11}",
+    color12    = "{color12}",
+    color13    = "{color13}",
+    color14    = "{color14}",
+    color15    = "{color15}",
+}


### PR DESCRIPTION
Since the 0.55 release, hyprlang (Hyprland's DSL) is deprecated for configuring the compositor, in favor of Lua.
I think since pywal16 supports Hyprland pre-0.55, it should continue to support the newer releases as well without the need for user-defined templates.

Here's a complete example of how it can be used in a Lua-based Hyprland config:
```lua
package.path = package.path .. ";" .. os.getenv("HOME") .. "/.cache/wal/colors.lua"

local ok, pywal = pcall(require, "colors")

if not ok then
    hl.exec_cmd("notify-send Hyprland 'Loading pywal colors failed'")
    pywal = { color6 = "#ffffff", color4 = "#7C0204" } -- fallback colors
end

hl.config({
    general =
        col = {
            active_border = { colors = { pywal.color6, pywal.color4 } },
            inactive_border = "rgba(00000000)"
        },
    },
})
```

Or, if the user doesn't care about errors:
```lua
package.path = package.path .. ";" .. os.getenv("HOME") .. "/.cache/wal/colors.lua"
local pywal = require("colors")

hl.config({ col = { active_border = { colors = { pywal.color6, pywal.color4 } } } })
```

Thanks for the awesome project! If any changes are necessary, I'll be happy to make them (I'm not a Python programmer though)
Cheers!